### PR TITLE
Convert to markdown

### DIFF
--- a/minutes/2020_04_08.md
+++ b/minutes/2020_04_08.md
@@ -1,4 +1,5 @@
 Stephan (and rest of Org Committee):
+
 * Revise web site
 * Figure out total # of support hours to request
 * Follow up with Alison Conroy re: GTW contract
@@ -8,25 +9,31 @@ Stephan (and rest of Org Committee):
 * Reach out to collaborators for 101 workshop
 
 Beth (and rest of Program Committee):
+
 * Draft preliminary program, with times in “Philadelphia time” (maybe outline this as a Slack post? That way, others can comment in a thread, and you can go back and edit the original post to synthesize)
 * Brainstorm ideas to engage attendees in a remote format (this may also be good as a post in Slack)
 
 Steve:
+
 * Get onto Slack! 
 Reach out to Medidata re: sponsorship
 
 Peter:
+
 * Reach out to Eric Topol re: keynote speakership
 * Reach out to additional pharma sponsors
 
 Dan:
+
 * Add Registration and Abstract Submission forms to the Google Doc for editing
 * Once website edits are done, update the live site
 
 Mara:
+
 * Email Stephan, Mike, and Joe to discuss diversity and inclusion initiatives
 * Reach out to Verily re: sponsorship
 
 Mike:
+
 * Once web site is live, tweet!
 * Reach out to Amgen and Vertex re: sponsorships

--- a/minutes/2020_05_27.md
+++ b/minutes/2020_05_27.md
@@ -1,30 +1,36 @@
 5/27/20 Agenda
 
 Review numbers:
+
 * Registrations
 * Abstracts (drafted, complete)
 * Revenue
 * bit.ly click throughs
 
 Web site:
+
 * Sponsorship logos needed for AACC, MSACL
 * Dan and Joe to work on getting administrative access to change R/Medicine website to Stephan
 
 Outreach:
+
 * Review Outreach List
 * This week’s tweet - EB ends 3/31,
 * Everyone to email groups in their institution for outreach. Talking points include that EB is ending; very inexpensive; postdocs = students; everybody with an *.edu address is an academic. Ask people to spread the work and also ask for contributions (mention the abstract due date of 6/24!). See Peter’s email for an example.
 
 Program:
+
 * Breaks into 6 sessions - have specific themes?
 * Start reviewing abstracts and filling program?
 * Are there people who we’d like to present?
 * Peter - ggconsort package hackathon?
 
 Platform:
+
 * Dan to plan dry run of Zoom and Crowdcast for 6/9 with everyone. Need a list of features we want to test.
 
 Sponsors:
+
 * RStudio - can RStudio help promote? Joe to explore
 * R consortium - can R consortium members help promote? Joe and Dan to explore
 * AMIA and Clinical Informatics fellows and directors - Mara to explore how we can promote
@@ -38,6 +44,7 @@ Sponsors:
 Minutes--
 
 Dan:
+
 * Post MSACL logo on r-medicine.com :white_check_mark:
 * Send list of emails of non-submitted abstracts to Beth so she can nag the authors
 * Email to everyone who registered, asking for a preference for workshop
@@ -45,14 +52,17 @@ Dan:
 * Create a deck of R/Medicine branded slides to use at the beginning of each talk. Slide 1: R/Med logo, and have space for talk title. Slide 2: An R/Medicine branded template to introduce the speaker, with space for a picture and a very short bio. Slide 3: A slide that will contain the logo of all sponsors
 
 Joe:
+
 * Contact Robert Gentleman re: talk title
 * Ask the RStudio social media team what it would take to re-tweet R/Medicine announcements on Twitter/LinkedIn
 
 Mike:
+
 * Contact Daniela Witten re: talk title and tweet
 * Reach out to groups at Yale (and document on the outreach sheet)
 
 Stephan:
+
 * Tweet about Stephan’s workshop - EB ends! Sign up today to reserve your space. 
 * Reach out to groups at Penn and CHOP 
 * Submit sponsorship application to Novartis 
@@ -62,10 +72,12 @@ Stephan:
 * Work with AACC on getting a webinar and marketing going
 
 Mara:
+
 * Work on tweet with Stephan 
 * Reach out to AMIA and Clinical Informaticists → do this once we have themes?
 
 Beth:
+
 * Review submitted abstracts
 * Get list of emails of pending abstract submissions from Dan and nag authors to complete their submissions
 * Create draft list of 6 “themes” for the conference sessions. One should probably be “R the clinical laboratory”, and that would be the one with Patrick Mathias as keynote and with MSACL and AACC giving their talks.

--- a/minutes/2020_06_03.md
+++ b/minutes/2020_06_03.md
@@ -1,5 +1,6 @@
 Agenda:
 Review numbers
+
 * Registrations
 * Diversity
 * Abstracts (drafted, complete)
@@ -9,11 +10,13 @@ Review numbers
 Web site
 
 Outreach
+
 * Review Outreach List
 * This week’s tweet. Should we send anything? Reach out for diversity/inclusion?
 * Please record outreach efforts in the Outreach List
 
 Program
+
 * Themes - Beth?
 * Should one of the themes be Social Inequality and Health?
 * Start reviewing abstracts and filling program?
@@ -21,9 +24,11 @@ Program
 * Peter - ggconsort package hackathon?
 
 Platform
+
 * Dan to plan dry run of Zoom and Crowdcast for 6/9 with everyone. Need a list of features we want to test.
 
 Sponsorships/Partnerships
+
 * R consortium - can R consortium members help promote?
 * AMIA and Clinical Informatics fellows and directors - Mara to explore how we can promote.
 * MSACL - organizing a panel discussion 07/01 with Stephan, Joe, and Mike attending. Stephan will provide a list of questions to discuss. Stephan got Dan Holmes from MSACL to speak.
@@ -36,21 +41,26 @@ Sponsorships/Partnerships
 Minutes: 
 
 Dan:
+
 * Send list of emails of non-submitted abstracts to Beth so she can nag the authors
 * Email to everyone who registered, asking for a preference for workshop
 
 Joe: 
+
 * Follow up with Robert Gentleman re: talk title
 
 Mike:
+
 * Send Daniela Witten’s abstract to Stephan and let her know we’re not tweeting this week
 
 Stephan:
+
 * Create a plan for testing Crowdcast and Zoom on 6/10
 * Create a deck of R/Medicine branded slides to use at the beginning of each talk. Slide 1: R/Med logo, and have space for talk title. Slide 2: An R/Medicine branded template to introduce the speaker, with space for a picture and a very short bio. Slide 3: A slide that will contain the logo of all sponsors
 * Work out MOU with with AACC
 * Reply to Gilbert David re: diversity/inclusion :white_check_mark:
 
 Beth:
+
 * Review submitted abstracts
 * Get list of emails of pending abstract submissions from Dan and nag authors to complete their submissions

--- a/minutes/2020_06_10.md
+++ b/minutes/2020_06_10.md
@@ -1,10 +1,12 @@
 6/10/20 Agenda
 
 Inclusion/Diversity: 
+
 * We will have Nonye Madu (CHOP), Mahmud Iqbal (CHOP) and potentially Becky Fogerty (CHOP), Alonso South (CHOP), and/or Danielle Smalls-Perkins (MiR - check this link) join us to discuss ways in which R/Medicine can do things that are useful for promoting equity and more specifically, broaden participation of underrepresented minority groups at R/Medicine.
 * Potentially useful initiatives include: (1) Broaden diversity of participation - remove barriers, outreach, prioritize workshop spots for PoC?; (2) Highlight work that stimulates discussion of health disparities and health consequences of inequality (even if not as polished as some other talks); (3) Discuss equity in predictive algorithms?
 
 Review numbers
+
 * Registrations - 135!
 * Diversity - no numbers yet
 * Abstracts (14 drafted in various stages, 5 complete)
@@ -12,15 +14,18 @@ Review numbers
 * bit.ly click throughs
 
 Platform:
+
 * Dan was going to do a dry-run of Zoom and Crowdcast today, but didn’t happen.
 * Need to discuss the user experience for registrants
 
 Outreach:
+
 * Review Outreach List
 * This week’s tweet: Daniela Witten? Also mention 2 week deadline for abstract submissions.
 * Reach out to your networks
 
 Program:
+
 * Themes: R in Clinical Practice; R in Clinical Research; R in Public Health and Health Disparities; Clinical Data Viz and Dashboards; New Analysis Approaches and Packages; Collaborative Clinical Research with R?
 * Start reviewing abstracts and filling program
 * Need list of participants so we can target invites to people who have already registered
@@ -28,6 +33,7 @@ Program:
 Web site
 
 Sponsorships/Partnerships:
+
 * Stephan spoke to Procogia about promotion and sponsorship. They are interested in paying for our platform.
 * AMIA and Clinical Informatics fellows and directors - Mara to explore how we can promote.
 * MSACL - organizing a panel discussion 07/01 with Stephan, Joe, and Mike attending. Stephan will provide a list of questions to discuss. Stephan got Dan Holmes from MSACL to speak.
@@ -40,18 +46,22 @@ Sponsorships/Partnerships:
 Minutes
 
 Everyone: 
+
 * Reach out to your networks and remind everyone of the 6/24 abstract deadline
 
 Joe:
+
 * Work with Dan to get access to a list of attendees ASAP
 * Work with Dan to clarify event operations: how will registrations be transferred to the event platform (e.g. Crowdcast). Conference landing page? Emailing participants 2 weeks before the event? Etc. Probably need to have a longer discussion.
 * Follow up with Robert Gentleman re: talk title
 
 Mike:
+
 * Send Daniela Witten’s abstract to Stephan 
 * Try to dig up registrations from past 2 years 
 
 Stephan:
+
 * Follow up with AACC about collaboration 
 * Compose a list of discussion questions for MSACL
 * Follow up with Novartis re: sponsorship 

--- a/minutes/2020_06_18.md
+++ b/minutes/2020_06_18.md
@@ -1,15 +1,18 @@
 6/18/20 Agenda
 
 Welcome Brian!
+
 * Taking over for Dan Lopez
 * Org committee basics (Slack, agenda, to-do list, email to group)
 * Concerns?
 
 Inclusion/Diversity:
+
 * Spoke to Nonye Madu (CHOP), Mahmud Iqbal (CHOP) and Danielle Smalls-Perkins (MiR - check this link) to discuss ways in which R/Medicine can do things that are useful for promoting equity and more specifically, broaden participation of underrepresented minority groups at R/Medicine. Working on partnership with MiR, more TBA.
 * Need stats about diversity among participants
 
 Review numbers:
+
 * Registrations
 * Diversity
 * Abstracts
@@ -17,16 +20,19 @@ Review numbers:
 * bit.ly click throughs
 
 Platform:
+
 * Current thinking is Zoom and Crowdcast, need to plan dry run urgently.
 * Need to discuss the user experience for registrants
 * Need to understand how registrations will be transferred from cvent -> platform. Contacted Jacynh (LF) about this, no response yet.
 
 Outreach:
+
 * Review Outreach List
 * This week’s tweet: Robert Gentleman? Also mention deadline for abstract submissions.
 * Reach out to your networks
 
 Program:
+
 * Themes: R in Clinical Practice; R in Clinical Research; R in Public Health and Health Disparities; Clinical Data Viz and Dashboards; New Analysis Approaches and Packages; Collaborative Clinical Research with R?
 * Start filling program with accepted abstracts
 * Need list of participants so we can target invites to people who have already registered
@@ -34,6 +40,7 @@ Program:
 Web site
 
 Sponsorships/Partnerships:
+
 * Stephan spoke to Procogia about promotion and sponsorship. They are interested in paying for our platform. Not sure if this is useful?
 * AMIA and Clinical Informatics fellows and directors - Mara to explore how we can promote.
 * MSACL - organizing a panel discussion 07/01 with Stephan, Joe, and Mike attending. Stephan will provide a list of questions to discuss. Stephan got Dan Holmes from MSACL to speak, need to follow up re: abstract.
@@ -43,26 +50,32 @@ Sponsorships/Partnerships:
 ----------------------------------------------------------------------------
 
 Everyone: 
+
 * Reach out to your networks and remind everyone of the 6/24 abstract deadline!
 
 Joe/Brian: 
+
 * Connect us with Colleen/Events team to scope out a platform and discuss how LF could support the event.
 * Figure out how to transfer R consortium funding for R/Medicine into our account
 * Mechanism of access to funds? (e.g., Reimbursement for personal expenses? Invoices to LF from vendors?)
 * Grant access to CFP dashboard to Stephan, Peter, Denise, Steve
+
 * Share list of registrants with Stephan and Beth so we can send targeted requests for proposals to people who have already registered.
 * We would like to know how many registrants self-identify as an underrepresented minority in tech. This is captured in the optional question “Aside from gender, if you identify with an underrepresented minority group in technology, please indicate that group below.” Can you include this field in the list of registrants?
 * Ask LF lawyers review the memo/contract from AACC
 
 Mike:
+
 * Reach out to registrants from past 2 years and ask them to spread the word about the conference and the conference deadline
 
 Stephan:
+
 * Compose a list of discussion questions for MSACL
 * Follow up with Procogia
 * Tweet / FB / LI - Robert Gentleman. 
 * On Monday - tweet that we’re extending submission
 
 Beth:
+
 * Review submitted abstracts
 * Once we have a list of registered attendees - review and see if there are folks we would like to invite to submit an abstract

--- a/minutes/2020_06_24.md
+++ b/minutes/2020_06_24.md
@@ -1,11 +1,13 @@
 6/24/20 Agenda
 
 Inclusion/Diversity:
+
 * Received proposal from MiR (Danielle Smalls, Dorris Scott). - they plan to share a coupon code ($10, same as student pricing) to MiR community and social platforms. They also want to host a BoF session at the conference. Offered to have a call to clarify. Question: plan with broadly sharing $10 coupon for everyone OK? Time limit? 07/01 - 07/14? Or better have dedicated “diversity scholarships”? Is someone going to get upset because they registered earlier? Are people going to expect a $10 coupon to come around and wait for that to register?
 * Stephan/Mara have reached out to Claudia Vitolo (R consortium / R-Ladies) and Samantha Toet (R consortium Diversity/Inclusion), setting up calls.
 * Need stats about diversity among participants
 
 Review numbers:
+
 * Registrations
 * Diversity
 * Abstracts
@@ -13,20 +15,25 @@ Review numbers:
 * bit.ly click throughs
 
 Platform:
+
 * Discussed platforms with Colleen Mickey (LF) today. LF has experience with virtual events, can support the event on the backend and moderate during the event. They have experience with several platforms and recommend 5, of which 2 have functionality we want and are potentially financially viable (Hopin, Meetingplay). Both provide integrated user experience, sponsor rooms and breakout rooms, and integrate with Zoom. Colleen will send budget and demos.
 
 Program:
+
 * Need to extend abstract deadline to 7/1 - changes in CFP required?
 * Start filling program with accepted abstracts
 
 Outreach:
+
 * This week’s tweet: MSACL? Also mention new deadline for abstract submissions.
 * Reach out to your networks
 
 Web site:
+
 * Changes needed for new abstract deadline 7/1
 
 Sponsorships/Partnerships:
+
 * R consortium - sponsorship for R/Medicine?
 * Stephan spoke to Procogia about promotion and sponsorship. They are interested in paying for our platform. Will forward them our Hopin budget.
 * AMIA and Clinical Informatics fellows and directors - Mara started outreach
@@ -37,9 +44,11 @@ Sponsorships/Partnerships:
 ------------------------------------------------------------------------
 
 Everyone: 
+
 * Reach out to your networks and remind everyone of the new 7/1 abstract deadline!
 
 Joe/Brian: 
+
 * Create $10 (total reg fee) and 20% off coupon codes, both valid from 7/1 through 7/14.
 * Create $0 reg codes for org cmt, workshop instructors/TAs, and keynote speakers
 * Questions about Hopin platform: PPTs supported (it appears so, but not in full screen mode)? Can we do speaker panels? If so, max # speakers on stage at the same time?
@@ -52,9 +61,11 @@ Joe/Brian:
 * Ask LF lawyers review the memo/contract from AACC 
 
 Mike:
+
 * Reach out to registrants from past 2 years and ask them to spread the word about the conference and the conference deadline
 
 Stephan:
+
 * Share a list of discussion questions for MSACL: https://docs.google.com/document/d/1z84aMoAjOeV1JcDvLbEDDqJfv44AeVzdC6db-ssqHu0/edit?usp=sharing 
 * Tweet / FB / LI - MSACL panel. Also: extended abstract deadline 
 * Follow up with MiR - don’t share code broadly please
@@ -62,9 +73,11 @@ Stephan:
 * Follow up with Novartis - new contact, updates?
 
 Mara:
+
 * Set up calls with Samantha (R consortium) and Claudia (R Ladies) re: diversity/inclusion
 * AMIA / Clinical Informatics outreach
 
 Beth:
+
 * Review submitted abstracts, start filling program
 * Review list of registered participants and see if there are folks we would like to invite to submit an abstract

--- a/minutes/2020_07_01.md
+++ b/minutes/2020_07_01.md
@@ -1,11 +1,14 @@
 Everyone:
+
 * Register using RMEDDC100 coupon code (100% off, don’t share!)
 * Reach out to your networks and ask people to spread the word to others who might benefit/be interested.
 
 Program Committee (Beth, Peter, Bob, Steve, Stephan):
+
 * Review abstracts and rank 1-5
 
 Joe/Brian:
+
 * What are the BoF sessions people suggested in the registration?
 * Contact registered participants about preference for workshop (one of: 101, 201, neither)
 * How can Beth see the results of the abstract rankings?
@@ -15,9 +18,11 @@ Joe/Brian:
 * Follow up with Procogia re: paying for platform
 
 Mike:
+
 * Reach out to registrants from past 2 years and ask them to spread the word about the conference and the conference deadline
 
 Stephan:
+
 * Tweet / FB / LI - MSACL? MiR?
 * Follow up with MiR - ready to retweet?
 * Follow up with Novartis - new contact, contract, updates?
@@ -25,13 +30,16 @@ Stephan:
 * Recruit TAs for workshops
 
 Mara:
+
 * Set up call with Samantha (R consortium) re: diversity/inclusion
 * AMIA / Clinical Informatics outreach
 
 Steve:
+
 * Outreach to industry partners - draft email and circulate
 
 Beth: 
+
 * Advise program committee members on review process, including deadline
 * Figure out how to review rankings from others
 * Draft BoF sessions and think of discussion leaders

--- a/minutes/2020_07_22.md
+++ b/minutes/2020_07_22.md
@@ -1,38 +1,46 @@
 07/22/20 Agenda
 
 Welcome Daniella Mark!
+
 * Introductions
 
 Review numbers:
+
 * Registrations
 * Abstracts
 * Revenue
 * bit.ly click throughs
 
 Program:
+
 * Program planning sheet → click here
 * Plan for BOFs
 * Need titles for Keynotes and sponsor / partner talks
 * Need to finalize abstract decisions and inform authors
 
 Platform / Logistics:
+
 * Main track: CrowdCast (Procogia). Plan to do dry run ASAP.
 * Short courses: Zoom (Yale or RStudio)
 * BOFs: Zoom?
 
 Inclusion/Diversity:
+
 * MiR shared coupon code on Slack and Twitter, will monitor registrations
 * Mara spoke with Sam Toet
 * We are collecting stats about diversity among participants
 
 Outreach:
+
 * This week’s tweet: Intro to R workshop, re-tweeted by MiR
 * Reach out to your networks - Steve Schwager offered to help
 
 Web site: 
+
 * Need to add sponsor logos for Procogia and AACC
 
 Sponsorships/Partnerships:
+
 * R consortium: submitted grant, waiting for response
 * Procogia: Daniella will support live event and Procogia will pay for CrowdCast. Need to put sponsor logo on website.
 * AMIA and Clinical Informatics fellows and directors: Mara working on outreach
@@ -44,31 +52,38 @@ Amgen, Vertex, Biogen?
 ---------------------------------------------------------------------------
 
 Everyone: 
+
 * Register!
 * Reach out to your networks and ask people to spread the word to others who might benefit/be interested — coordinate with Steve Schwager
 
 Program Committee (Beth, Peter, Bob, Steve, Stephan):
+
 * Select BOFs and put them in the schedule
 * Finalize abstract decisions and inform authors
 * Register keynote speakers
 * Think of Zoom Pro sponsors who could “donate” rooms for the conference days (Yale? RStudio? others?)
 
 Joe/Brian:
+
 * Add Procogia and AACC logos to website
 * Follow up on RUGS grant
 
 Stephan:
+
 * Follow up with Novartis and Biogen
 * Get titles for AACC and MSACL lightning talks
 * Work with AACC to get panel discussion going
 
 Daniella:
+
 * Create Crowdcast account
 * How to transfer registrations from cvent.com to Crowdcast?
 * Work with Beth and Stephan to test crowdcast
 
 Mike:
+
 * Reach out to registrants from past 2 years and ask them to spread the word about the conference and the conference deadline
 
 Mara:
-* AMIA / Clinical Informatics outreach
+
+* AMIA / Clinical Informatics outreachs

--- a/minutes/2020_07_29.md
+++ b/minutes/2020_07_29.md
@@ -1,33 +1,40 @@
 07/29/20 Agenda
 
 Review numbers:
+
 * Registrations - 238!
 * Promo campaigns: RMED20MIR, RMED20MSACL, ?REVO20IR, ?RMED20NPR
 * Revenue
 * bit.ly click throughs
 
 Program:
+
 * Program planning sheet → click here
 * Plan for BOFs?
 * Need titles for Keynotes, MSACL, AACC talks
 * Need to finalize abstract decisions and inform authors
 
 Platform / Logistics:
+
 * Main track: CrowdCast (Procogia). Plan to do dry run ASAP.
 * Short courses: Zoom (Yale? RStudio? Buy ourselves?). How are we dealing with cap of 50 people on Tidymodels course?
 * BOFs: Zoom?
 
 Inclusion/Diversity:
+
 * Plan to re-engage MiR / R-Forwards in 1-2 weeks
 
 Outreach:
+
 * Need to engage each committee member’s networks. No one from Yale, 1 person from Mayo, no one from RStudio, 2 from Michigan. Stephan will share examples.
 * This week’s tweet - highlight a contributed talk? Of someone with a large network? Or re-highlight tidymodels? Might not go over well if registrations capped
 
 Web site: 
+
 * Need to add sponsor logo for Procogia
 
 Sponsorships/Partnerships: 
+
 * R consortium: submitted grant, waiting for response
 * Procogia: Daniella will support live event and Procogia will pay for CrowdCast. Need to put sponsor logo on website.
 * AMIA and Clinical Informatics fellows and directors: Mara reached out. Results?
@@ -37,22 +44,27 @@ Sponsorships/Partnerships:
 ------------------------------------------------------------------------
 
 Everyone:
+
 * Register!
 * Outreach! Stephan will send examples of what he’s sent around at CHOP
 
 Program Committee (Beth, Peter, Bob, Steve, Stephan):
+
 * Select 6-9 BOFs and put them in the schedule
 * Finalize abstract decisions and inform authors
 * Register keynote speakers
 
 Peter:
+
 * Reach out to Ewen Harrison to ask for talk title, brief summary, speaker info
 
 Joe:
+
 * Follow up on RUGS grant
 * Reach out to Robert Gentleman to ask for talk title, brief summary, speaker info
 
 Brian:
+
 * Add Procogia logo to website
 * Send updated list of suggested BoFs to Beth, disable field on registration form
 * Create Hugo site for R/Med 2020 program
@@ -61,6 +73,7 @@ Brian:
 * Send CFP site data to Stephan
 
 Stephan:
+
 * Send sample promo materials I distributed at CHOP/Penn
 * Get title/abstract/speaker info for Steve Master’s AACC talk and Patrick Mathias’ keynote
 * Add program to empty R/Med 2020 program site
@@ -70,9 +83,11 @@ Stephan:
 * Work with Brian and Alison Hill to draft an email to get people to sign up for Tidymodels course
 
 Daniella:
+
 * Figure out how to transfer registrations from cvent.com to Crowdcast. Zapier?
 * Help us find a Zoom plan to support workshops and BoFs.
 * Run through crowdcast test
 
 Mike:
+
 * Reach out to registrants from past 2 years and ask them to spread the word about the conference and the conference deadline

--- a/minutes/2020_08_05.md
+++ b/minutes/2020_08_05.md
@@ -1,32 +1,39 @@
 08/05/20 Agenda
 
 Review numbers:
+
 * Registrations - 276!!
 * Promo campaigns: RMED20MIR (9), RMEDCFP2020 (2)
 * Revenue
 * bit.ly click throughs
 
 Program:
+
 * Program planning sheet → click here
 * Consider switching times based on time zone analysis (Stephan).
 * Possible to add final program (minus late-breaking talks) onto main site, with new times?
 * Plan for BOFs: 3 rooms, need to pick 9 from the list
 
 Platform / Logistics:
+
 * Main track: CrowdCast (Procogia). Review dry run (Daniella). Discuss transfer of registration data from cvent to CC
 * BoFs: Zoom
 * Short courses: Zoom. Stephan will run a series of planning meetings with instructors and TAs. More to follow.
 
 Inclusion/Diversity:
+
 * Plan to re-engage MiR / R-Forwards
 
 Outreach:
+
 * This week’s tweet - highlight one or more contributed talks?
 
 Web site:
+
 * Add final schedule
 
 Sponsorships/Partnerships:
+
 * consortium: received $1000 RUGS grant, need to forward to R/Med account
 * Procogia: NTD
 * AMIA and Clinical Informatics fellows and directors: Mara reached out. Results?
@@ -36,23 +43,28 @@ Sponsorships/Partnerships:
 ----------------------------------------------------------------------
 
 Everyone: 
+
 * Register!
 
 Beth:
+
 * Add BoFs to the schedule
 * Register keynote speakers
 * Reach out to speakers with next steps (Brian might have a template) - including offering pre-recorded submission, LF first-time speaker course, what to expect at CrowdCast, deadlines for materials, etc
 
 Joe: 
+
 * Follow up on RUGS grant - deposit into R/Med account
 
 Brian:
+
 * Send CFP site data to Stephan as Excel data
 * Expense Stephan for Zoom account
 * Update microsite with schedule
 * Send responses to “what workshop do you plan to attend?” questions to Stephan
 
 Stephan:
+
 * Send final schedule to Brian to update web site
 * Coordinate with AACC re: promotional materials
 * Follow up with Alison re: new time and recordings :white_check_mark:
@@ -62,5 +74,6 @@ Stephan:
 * Figure out whether we can add on additional free Zoom rooms for additional BoFs and troubleshooting rooms?
 
 Daniella:
+
 * Figure out how to transfer registrations from cvent.com to Crowdcast. CSV import? Which data fields are supported?
 * Run through crowdcast test: (1) register participants (Beth and me?), (2) progress between sessions; (3) CTA link to Zoom rooms (only 1 link possible, need this to forward to a list of links).

--- a/minutes/2020_08_12.md
+++ b/minutes/2020_08_12.md
@@ -1,40 +1,49 @@
 08/12/20 Agenda
 
 Review numbers: 
+
 * Registrations - 352!!
 * Promo campaigns: RMED20MIR (12), RMEDCFP2020 (2), RMEDDC21 (20), RMED10MSACL (8)
 * Revenue
 * bit.ly click throughs
 
 Program:
+
 * Program planning sheet → click here
 * Need to finalize program and update website ASAP
 * Plan for BOFs: 5 rooms. Need to invite / assign moderators.
 
 Talks:
+
 * Daniella drafted speaker guidance
 * Deadline for pre-recorded talks
 * Workflow/script for bringing speakers online with CC - test run later today
 
 Workshops:
+
 * Need to assign/register participants to live workshops. Alison + Stephan working on email / Google forms survey, needs to be sent by R/Medicine
 * After, need to send workshop login info to registered participants.
 * Stephan and Alison working on surveys and emails
 
 Platform / Logistics:
+
 * Main track: CrowdCast (Procogia). Review dry run (Daniella). Discuss transfer of registration data from cvent to CC
 * BoFs: Zoom, need 2 more licenses
 
 Inclusion/Diversity:
+
 * NTD
 
 Outreach:
+
 * NTD
 
 Web site:
+
 * Add final schedule
 
 Sponsorships/Partnerships:
+
 * R consortium: received $1000 RUGS grant, need to forward to R/Med account
 * Procogia: NTD
 * AMIA and Clinical Informatics fellows and directors: Mara reached out. Results?
@@ -44,22 +53,27 @@ Sponsorships/Partnerships:
 ------------------------------------------------------------------------
 
 Everyone:
+
 * Register, if you haven’t yet.
 
 Beth:
+
 * Assign a moderator to each BoF
 * Review speaker guidance and send out as soon as schedule is up on the website
 
 Joe:
+
 * Follow up on RUGS grant - deposit into R/Med account
 
 Brian:
+
 * Add another 50 folks to RMEDDC100 coupon code (speakers)
 * Update Schedule at a Glance on the microsite
 * Follow up with Events team about “Which workshop do you plan to attend” question. I can’t see anything in the report you sent to me.
 * Expense Stephan for Zoom account
 
 Stephan:
+
 * Create final schedule and send to Brian and AACC :white_check_mark:
 * Buy 2 more Zoom licenses and Zoom rooms
 * Figure out how to run 5 Zoom rooms concurrently. Need to run VMs?
@@ -74,6 +88,7 @@ Stephan:
 * Submit rstudio::global abstract
 
 Daniella:
+
 * Invite everyone to tonight’s CrowdCast dry run
 * Run through crowdcast test with group
 * Draft slide deck template to show at the beginning of each talk

--- a/minutes/2020_08_19.md
+++ b/minutes/2020_08_19.md
@@ -1,20 +1,24 @@
 08/12/20 Agenda
 
 Review numbers:
+
 * Registrations - 413!
 * Promo campaigns: RMED20MIR (12), RMEDCFP2020 (4), RMEDDC100 (25), RMED10MSACL (8), RMED20LADIES (1), RMED20AACC (0)
 * Revenue
 
 Program:
+
 * One person was left off the final program - should we double check that this was the only one? Fix the program on the website?
 * BoFs - Beth made a list with assignments. Need to test people opening rooms as licensed Zoom hosts. Need landing pages for BoFs to send people to the rooms. Demo / test both today.
 * Zoom settings for BoFs: host is a licensed Zoom user, rmed2020user1@hideaddress.net, etc., with password R@Med2020!. Hosts will need to sign in using those user credentials. Meetings will have passcode “rmed”.  Participant video will be on, and participants will not be muted upon entry. Meetings will not be recorded.
 
 Talks:
+
 * Speaker guidance sent. Are all speakers in Slack?
 * Workflow for bringing speakers online with CC - Daniella
 
 Workshops:
+
 * Unexpectedly high level of interest in Tidymodels, had to cap at 80.
 * Troubleshooting Guide for TAs
 * Daniella will host dry run for TAs on Thursday
@@ -22,11 +26,14 @@ Workshops:
 101: Stephan is working on: creating workshop materials -> GitHub; getting registrations for course; welcome email; landing page; building rstudio.cloud environment; building RSP training environment; pre and post course surveys.
 
 Outreach:
+
 * Twitter - communicate that Tidymodels is full, Intro to R still has spots, last day to reg for live attendance is Sunday 8/23. Everyone please re-tweet.
 
 Web site:
+
 * Fix schedule?
 
 Sponsorships/Partnerships:
+
 * R consortium: received $1000 RUGS grant, need to forward to R/Med account
 * AACC: panel discussion on 8/20, promotion ongoing.

--- a/minutes/2020_08_26.md
+++ b/minutes/2020_08_26.md
@@ -1,24 +1,31 @@
 08/26/20 Agenda
 
 :baby: Welcome to the world, Baby Alexeev! :baby:
-:rmedicine: R/Medicine 2020 starts TOMORROW! :rmedicine:
+
+:rmedicine: R/Medicine 2020 starts 
+
+TOMORROW! :rmedicine:
 
 Review numbers:
+
 * Registrations - 536! Will we leave registration open? I think yes?
 * Promo campaigns: RMED20MIR (12), RMED20LADIES (3), RMED10MSACL (8), RMED20AACC (12)
 * Revenue
 * Countries: 41 (!!!)
 
 Program:
+
 * Run through program, discuss mechanics: main session and BoFs. Download the “DoorbellSounds” app!
 * Opening remarks
 
 Communications: 
+
 * To people who signed up for 201 on cvent but not on the Google Form: sorry for late communication, and for the mess.
 * To all registrants: welcome, and how to join the main session, how to watch a recorded session, how to get back to the live session. People should check their spam folder if they think . Apologize again for capping the 201 course and remind people that recordings will be there and all materials posted online. (How will we forward this email to people who sign up after that email goes out?)
 * Final speaker instructions: be there for your whole block. Be reachable on Slack.
 
 Outreach:
+
 * Peter will live tweet from @r_medicine
 * Blog post on RViews
 * rstudio::conf 2021 abstract (due 8/28)
@@ -27,6 +34,7 @@ Outreach:
 * Nick nacks for keynote speakers
 
 Reimbursements:
+
 * We should return payments for the following people: speakers, workshop instructors, TAs, org cmt members
 * Honorarium for workshop leaders
 * Zoom, DigitalOcean, Stickermule

--- a/minutes/2020_09_09.md
+++ b/minutes/2020_09_09.md
@@ -1,11 +1,13 @@
 09/09/20 Agenda
 
 Postmortem:
+
 * Final stats
 * What worked
 * What didn’t work
 
 Post-Conference:
+
 * Videos - intro, post on YouTube
 * Forever website (2020.r-medicine.org?)
 * Gift for keynote speakers
@@ -14,15 +16,17 @@ Post-Conference:
 * Reimbursements
 
 The Future:
+
 * Sustainability
 * Knowledge management (including credentials)
 * R/Medicine 2021
 * Regular events: talks, workshops
 * Sponsorship strategy
 
-------------------------------------------------------------------------
+---
 
 Stephan:
+
 * Process videos and upload to YouTube 
 * Build forever site and post links to videos there
 * Ask CHOP CME office for ways to work with R/Medicine to provide CME for online events
@@ -33,25 +37,31 @@ Stephan:
 * Look into Google Docs vs Confluence as a knowledge management platform
 
 Daniella:
+
 * Send S.A.S.Es to Stephan (collect until a few days after the stated deadline, maybe on 9/18?)
 * Ask Brian to set up a Zoom account for R/Medicine 
 * Work with Stephan to set up Shiny workshop for the ProCogia consultant (we should write a playbook / HowTo at that time for future reference)
 
 Peter:
+
 * Ask U Michigan CME office for ways to work with R/Medicine to provide CME for online events
 * Add to a list of potential sponsors for R/Medicine 2021 
 
 Joe:
+
 * Find out credentials for R consortium YouTube channel, tell Stephan
 Draft blog post about R/Medicine 2020
 
 Mara:
+
 * Draft a charter for R/Medicine
 
 Beth:
+
 * Design and send gift to keynote speakers
 
 Brian: 
+
 * Pay honoraria to workshop instructors
 * Tell Stephan credentials for R consortium YouTube channel and r-medicine.org domain
 * Set up mailing list for R/Medicine events, starting with people who have opted in during R/Med 2020 registration


### PR DESCRIPTION
This commit converts the meeting minutes to markdown.
* Adds a '.md' file extension
* Adds a blank line before each list, so that they are rendered as bullet points

Signed-off-by: Brian Warner <brian@bdwarner.com>