### PR TITLE
Add a markdown meeting template

### DIFF
--- a/minutes/meeting_template.md
+++ b/minutes/meeting_template.md
@@ -1,0 +1,26 @@
+# R Consortium R Medicine Working Group Meeting: Date
+
+## Meeting information
+
+**Date, time**
+
+* Zoom:
+* Recording:
+* How to join:
+
+## Attendees
+
+* Attendee 1
+* Attendee 2
+* ...
+
+## Agenda
+
+1. Item 1
+1. Item 2
+   1. Sub-item
+1. ...
+
+## Minutes
+
+


### PR DESCRIPTION
In case it makes things easier, here's a basic meeting template. Some projects will create future meeting templates in batches, one for each date of the meeting, and then have people add their own agenda items as pull requests. Right before the meeting, then they get merged and there's the agenda. You don't have to use this process, but I'm just putting it out there as something which has worked for others.

Signed-off-by: Brian Warner <brian@bdwarner.com>